### PR TITLE
[Edit] SignIn Logic //아직 머지하지말아주세요...!(더보기...)

### DIFF
--- a/HANE24/ContentView.swift
+++ b/HANE24/ContentView.swift
@@ -18,20 +18,17 @@ struct ContentView: View {
             if !signInChecked {
                 LoadingView()
             } else {
-                if hane.status == .afterSignIn {
+                switch hane.isSignIn{
+                case false:
+                    SignInView()
+                case true:
                     MainView()
-                } else if hane.status == .beforeSignIn {
-                    SignInView(hane: hane)
-                } else if hane.status == .loadWebView {
-                    SignInWebView()
-                } else {
-                    LoadingView()
                 }
             }
         }
         .task{
             do{
-                try  hane.status = await hane.isLogin() ? .afterSignIn : .beforeSignIn
+                try  hane.isSignIn = await hane.isLogin() ? true : false
                 self.signInChecked = true
             } catch {
                 print("Invalid URL")

--- a/HANE24/View/SignInView.swift
+++ b/HANE24/View/SignInView.swift
@@ -7,55 +7,79 @@
 
 import SwiftUI
 
+enum Stat {
+    case buttonNotTabbed
+    case buttonTabbed
+    case viewAppeared
+    case readyToSignIn
+}
+
 struct SignInView: View {
     
-    @ObservedObject var hane : Hane
+    @EnvironmentObject var hane : Hane
+    @State var viewStat: Stat = .buttonNotTabbed
     
     var body: some View {
         ZStack{
-            LinearGradient(gradient: Gradient(colors: [.gradientPurple, .gradientBlue]), startPoint: .bottomLeading, endPoint: .topTrailing)
-                .ignoresSafeArea()
-            VStack(alignment: .center){
-                ZStack(alignment: .bottomLeading){
-                    Rectangle()
-                        .fill( LinearGradient(gradient: Gradient(colors: [.gradientPurple, .gradientBlue]), startPoint: .bottomLeading, endPoint: .topTrailing))
-                        .frame(width: 150, height: 150)
-                    VStack(alignment: .leading){
-                        Text("24")
-                            .font(.system(size: 35, weight: .semibold))
-                        Text("HANE")
-                            .font(.system(size: 35, weight: .heavy))
-                    }
-                    .padding(10)
-                    .foregroundColor(.white)
-                }
-                .padding(.bottom, 70)
-                Text("입실과 퇴실의 짝이 일치하는 경우에만 출입 누적시간이 반영됩니다.")
-                    .foregroundColor(.white)
-                    .font(.system(size: 12, weight: .regular))
-                Text("입/퇴실 시 출입카드를 꼭 태깅해주세요.")
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundColor(.white)
-                Button{
-                    hane.status = .loadWebView
-                } label: {
-                    ZStack{
-                        RoundedRectangle(cornerRadius: 10)
-                            .foregroundColor(Color.DarkDefaultBG)
-                        Text("LOG IN")
+            SignInWebView(viewStat: $viewStat)
+            if viewStat != .readyToSignIn{
+                ZStack{
+                    LinearGradient(gradient: Gradient(colors: [.gradientPurple, .gradientBlue]), startPoint: .bottomLeading, endPoint: .topTrailing)
+                        .ignoresSafeArea()
+                    VStack(alignment: .center){
+                        ZStack(alignment: .bottomLeading){
+                            Rectangle()
+                                .fill( LinearGradient(gradient: Gradient(colors: [.gradientPurple, .gradientBlue]), startPoint: .bottomLeading, endPoint: .topTrailing))
+                                .frame(width: 150, height: 150)
+                            VStack(alignment: .leading){
+                                Text("24")
+                                    .font(.system(size: 35, weight: .semibold))
+                                Text("HANE")
+                                    .font(.system(size: 35, weight: .heavy))
+                            }
+                            .padding(10)
                             .foregroundColor(.white)
+                        }
+                        .padding(.bottom, 70)
+                        Text("입실과 퇴실의 짝이 일치하는 경우에만 출입 누적시간이 반영됩니다.")
+                            .foregroundColor(.white)
+                            .font(.system(size: 12, weight: .regular))
+                        Text("입/퇴실 시 출입카드를 꼭 태깅해주세요.")
+                            .font(.system(size: 12, weight: .regular))
+                            .foregroundColor(.white)
+                        Button{
+                            if self.viewStat == .viewAppeared {
+                                self.viewStat = .readyToSignIn
+                            } else {
+                                self.viewStat = .buttonTabbed
+                            }
+                        } label: {
+                            ZStack{
+                                RoundedRectangle(cornerRadius: 10)
+                                    .foregroundColor(Color.DarkDefaultBG)
+                                if viewStat != .buttonTabbed {
+                                    Text("LOG IN")
+                                        .foregroundColor(.white)
+                                }
+                                else {
+                                    /// [FixMe] ProgressView -> Progress[Dot] with Gradient => passthroughSubject??
+                                    ProgressView()
+                                        .foregroundColor(.white)
+                                }
+                            }
+                        }
+                        .frame(height: 45)
+                        .padding(10)
                     }
+                    .padding(.horizontal, 10)
                 }
-                .frame(height: 45)
-                .padding(10)
             }
-            .padding(.horizontal, 10)
         }
     }
 }
 
 struct SignInView_Previews: PreviewProvider {
     static var previews: some View {
-        SignInView(hane: Hane())
+        SignInView()
     }
 }

--- a/HANE24/View/ViewModel/HaneVM.swift
+++ b/HANE24/View/ViewModel/HaneVM.swift
@@ -20,6 +20,7 @@ class Hane: ObservableObject {
     @Published var dailyAccumulationTime: Int64 = 0
     @Published var monthlyAccumulationTime: Int64 = 0
     @Published var status: Status = .beforeSignIn
+    @Published var isSignIn: Bool = false
     @Published var monthlyLogs: [Date: [InOutLog]] = [:]
     @Published var dailyTotalTimesInAMonth: [Int64] = Array(repeating: 0, count: 32)
     
@@ -34,6 +35,7 @@ class Hane: ObservableObject {
         self.dailyAccumulationTime = 0
         self.monthlyAccumulationTime = 0
         self.status = .beforeSignIn
+        self.isSignIn = false
         self.monthlyLogs = [:]
         self.dailyTotalTimesInAMonth = []
         
@@ -146,7 +148,7 @@ class Hane: ObservableObject {
                     }
                 })
         UserDefaults.standard.removeObject(forKey: "Token")
-        self.status = .beforeSignIn
+        self.isSignIn = false
     }
 }
 


### PR DESCRIPTION
[Edit] SignIn Logic -> ContentView, SignInView, SignInWebView
[Edit] Hane status: Status => (Hane)isSignIn: Bool + (SignInView)viewStat: Stat

그 지금 hane의 status로 signInView, SignInWebView 와리가리하면 signInView에서 contentView까지 다시 나갔다가 같은 화면으로 들어오는 형태가 되는 것 같아서,,, signInView <-> SignInWebView간의 와리가리를 SignInView 내의 @ State로 하고 그렇게 되면 status에서 쓰이는게 beforeSignIn, afterSignIn밖에 없게 되어서 isSignIn : Bool 로 새로 만들고 (status는 안 없앴습니다!! 우선 그냥 뒀어요)  그걸쓰는 형태로 한번 해봤습니당 완성은 되었는데 아직 어떨지 몰라서 0223(수요일) 에 같이 보고 결정하시죵..!! 머지도 결졍되고 나먄...!!넵...!!