### PR TITLE
[link] new API

### DIFF
--- a/HANE24.xcodeproj/project.pbxproj
+++ b/HANE24.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		0E6B608F29AC850D009D8BC4 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6B608E29AC850D009D8BC4 /* NetworkManager.swift */; };
 		0EE58193299CC24000EE3351 /* MoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE58192299CC24000EE3351 /* MoreView.swift */; };
 		0EE58198299CC74C00EE3351 /* ReissuanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE58197299CC74C00EE3351 /* ReissuanceView.swift */; };
+		0EEB0E2429AE2AF700FEB700 /* CardProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB0E2329AE2AF700FEB700 /* CardProgressView.swift */; };
+		0EEB0E2629AE303100FEB700 /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB0E2529AE303100FEB700 /* AlertView.swift */; };
 		0EFAF5B829A492A500125948 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFAF5B729A492A500125948 /* SignInView.swift */; };
 		0EFAF5BC29A4D8E100125948 /* contentViewTmp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFAF5BB29A4D8E100125948 /* contentViewTmp.swift */; };
 		0EFAF5BE29A4D97800125948 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFAF5BD29A4D97800125948 /* LoadingView.swift */; };
@@ -61,6 +63,8 @@
 		0E6B608E29AC850D009D8BC4 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		0EE58192299CC24000EE3351 /* MoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreView.swift; sourceTree = "<group>"; };
 		0EE58197299CC74C00EE3351 /* ReissuanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissuanceView.swift; sourceTree = "<group>"; };
+		0EEB0E2329AE2AF700FEB700 /* CardProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardProgressView.swift; sourceTree = "<group>"; };
+		0EEB0E2529AE303100FEB700 /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		0EFAF5B729A492A500125948 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		0EFAF5BB29A4D8E100125948 /* contentViewTmp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = contentViewTmp.swift; sourceTree = "<group>"; };
 		0EFAF5BD29A4D97800125948 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -161,6 +165,8 @@
 			children = (
 				0EE58192299CC24000EE3351 /* MoreView.swift */,
 				0EE58197299CC74C00EE3351 /* ReissuanceView.swift */,
+				0EEB0E2329AE2AF700FEB700 /* CardProgressView.swift */,
+				0EEB0E2529AE303100FEB700 /* AlertView.swift */,
 			);
 			path = More;
 			sourceTree = "<group>";
@@ -284,6 +290,7 @@
 				9A37714929A742C0006BBEF3 /* CoreDataVM.swift in Sources */,
 				0E17EFAA299B5C0A0089BCD8 /* PopulationView.swift in Sources */,
 				0E165510299A5A82001E5EED /* HomeView.swift in Sources */,
+				0EEB0E2629AE303100FEB700 /* AlertView.swift in Sources */,
 				9AF730F1299D58F100AF2E53 /* AccTimeCardForCalendarView.swift in Sources */,
 				9AF730FD299F602D00AF2E53 /* JSONs.swift in Sources */,
 				0E1654FC299A285E001E5EED /* Persistence.swift in Sources */,
@@ -305,6 +312,7 @@
 				9AF730FB299F53C700AF2E53 /* HaneVM.swift in Sources */,
 				0E165508299A3C20001E5EED /* ChartView.swift in Sources */,
 				0E1654F3299A285B001E5EED /* HANE24App.swift in Sources */,
+				0EEB0E2429AE2AF700FEB700 /* CardProgressView.swift in Sources */,
 				0E17EFAC299B6CCD0089BCD8 /* notificationView.swift in Sources */,
 				0E51FE1B29A9D958008A01B6 /* HANE24.xcdatamodeld in Sources */,
 				0EFAF5BC29A4D8E100125948 /* contentViewTmp.swift in Sources */,

--- a/HANE24/Model/JSONs.swift
+++ b/HANE24/Model/JSONs.swift
@@ -30,11 +30,17 @@ struct MainInfo: Codable {
     let profileImage: String
     let inoutState: String
     let tagAt: String?
+    let gaepo: String
+    let seocho: String
 }
 
 struct AccumulationTimes: Codable {
     let todayAccumationTime: Int64
     let monthAccumationTime: Int64
+}
+
+struct ReissueState: Codable {
+    let state: String
 }
 
 
@@ -51,3 +57,5 @@ struct ClusterTmp: Codable {
     let GaePo: Int64
     let Seocho: Int64
 }
+
+

--- a/HANE24/View/Calendar/CalendarGridView.swift
+++ b/HANE24/View/Calendar/CalendarGridView.swift
@@ -23,6 +23,8 @@ struct CalendarGridView: View {
                     selectedDate = Calendar.current.date(byAdding: .month, value: -1, to: selectedDate)!
                     Task{
                         try await hane.updateMonthlyLogs(date: selectedDate)
+                        print("selectedDAte\(selectedDate)")
+                        print("permonth! : \(hane.perMonth)")
 //                        isLoaded = true
                     }
 

--- a/HANE24/View/Home/HomeView.swift
+++ b/HANE24/View/Home/HomeView.swift
@@ -14,7 +14,6 @@ struct chartItem: Identifiable {
     var data: Array<Double>
 }
 
-<<<<<<< HEAD
 func getWeeklyPeriod() -> [String]{
     var weeklyPeriod:[String] = []
     var date = Date()
@@ -162,7 +161,7 @@ struct HomeView: View {
                                 UserDefaults.standard.setValue(selection, forKey: "MonthlySelectionOption")
                             }
                                 .padding(.horizontal, 30)
-                            
+
                             TabView{
                                 ChartView(item: chartItem(id: "주", title: "최근 주간 그래프", period: getWeeklyPeriod(), data: hane.recent6Weeks))
                                     .padding(.horizontal, 10)

--- a/HANE24/View/Home/PopulationView.swift
+++ b/HANE24/View/Home/PopulationView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct PopulationView: View {
+    @EnvironmentObject var hane: Hane
     var body: some View {
         VStack(alignment: .center, spacing: 8) {
             HStack{
@@ -26,7 +27,7 @@ struct PopulationView: View {
                             .font(.system(size: 16, weight: .semibold))
                             .padding(.trailing, 20)
                             .foregroundColor(.black)
-                        Text("\(420)명")
+                        Text("\(hane.mainInfo.gaepo)명")
                             .font(.system(size: 16, weight: .semibold))
                             .padding(.leading, 20)
                             .foregroundColor(.black)
@@ -41,7 +42,7 @@ struct PopulationView: View {
                             .font(.system(size: 16, weight: .semibold))
                             .padding(.trailing, 20)
                             .foregroundColor(.black)
-                        Text("\(240)명")
+                        Text("\(hane.mainInfo.seocho)명")
                             .font(.system(size: 16, weight: .semibold))
                             .padding(.leading, 20)
                             .foregroundColor(.black)
@@ -55,5 +56,6 @@ struct PopulationView: View {
 struct PopulationView_Previews: PreviewProvider {
     static var previews: some View {
         PopulationView()
+            .environmentObject(Hane())
     }
 }

--- a/HANE24/View/More/AlertView.swift
+++ b/HANE24/View/More/AlertView.swift
@@ -1,0 +1,99 @@
+//
+//  AlertView.swift
+//  HANE24
+//
+//  Created by Katherine JANG on 2/28/23.
+//
+
+import SwiftUI
+
+
+
+struct AlertView: View {
+    @Binding var showAlert: Bool
+    @EnvironmentObject var hane: Hane
+    var item: alertItem
+    var body: some View {
+        ZStack{
+            GeometryReader { _ in
+                EmptyView()
+            }
+            .background(Color.gray.opacity(0.7))
+            .opacity(0.5)
+            RoundedRectangle(cornerRadius: 20)
+                .foregroundColor(.white)
+                .frame(width: 300, height: 300)
+            VStack{
+                Text(item.title1)
+                    .font(.system(size: 16, weight: .bold))
+                Text(item.title2)
+                    .font(.system(size: 16, weight: .bold))
+                Text(item.statement)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundColor(.gradientPurple)
+                    .padding()
+                if item.id == "신청" {
+                    submitButton
+                } else {
+                    receiveButton
+                }
+                Button {
+                    showAlert.toggle()
+                } label: {
+                    ZStack{
+                        RoundedRectangle(cornerRadius: 10)
+                            .foregroundColor(.LightDefaultBG)
+                            .frame(width: 250, height: 50)
+                        Text("취소")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundColor(.black)
+                    }
+                }
+
+            }
+        }
+        .background(Color.gray.opacity(0.7))
+    }
+    
+    var submitButton: some View {
+        Button{
+            Task {
+               try await hane.postJsonAsync()
+            }
+            hane.reissueState = .inProgress
+            showAlert.toggle()
+        } label: {
+            ZStack{
+                RoundedRectangle(cornerRadius: 10)
+                    .foregroundColor(.gradientPurple)
+                    .frame(width: 250, height: 50)
+                Text("네, 신청하겠습니다")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+            }
+        }
+    }
+    
+    var receiveButton: some View {
+        Button{
+            hane.reissueState = .beforeReissue
+            showAlert.toggle()
+        } label: {
+            ZStack{
+                RoundedRectangle(cornerRadius: 10)
+                    .foregroundColor(.gradientPurple)
+                    .frame(width: 250, height: 50)
+                Text("네, 확인했습니다")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+            }
+        }
+    }
+}
+
+struct AlertView_Previews: PreviewProvider {
+    static var previews: some View {
+        AlertView(showAlert: .constant(true), item:  alertItem(id: "신청", title1: "카드 재발급을", title2: "신청하시겠습니까?", statement: "신청 후 취소가 불가능합니다.", buttonTitle: "네, 신청하겠습니다"))
+            .environmentObject(Hane())
+    }
+}

--- a/HANE24/View/More/CardProgressView.swift
+++ b/HANE24/View/More/CardProgressView.swift
@@ -1,0 +1,42 @@
+//
+//  CardProgressView.swift
+//  HANE24
+//
+//  Created by Katherine JANG on 2/28/23.
+//
+
+import SwiftUI
+
+struct CardProgressView: View {
+    var item: progressItem
+    
+    var body: some View {
+
+        HStack(spacing: 15) {
+            ZStack{
+                Circle()
+                    .stroke(lineWidth: 4)
+                    .overlay( item.isProcessing ? Circle() : nil)
+                    .foregroundColor(item.isProcessing ? .gradientPurple : Color(hex: "EAEAEA"))
+                    .frame(width: 50, height: 50)
+                Text(item.id)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(item.isProcessing ?  Color(hex: "EAEAEA") : .iconColor)
+            }
+            VStack(alignment: .leading, spacing: 5) {
+                Text(item.title)
+                    .font(.system(size: 16, weight: .bold))
+                Text(item.statement)
+                    .font(.system(size: 14, weight: .regular))
+            }
+        }
+        .padding()
+    }
+
+}
+
+struct CardProgressView_Previews: PreviewProvider {
+    static var previews: some View {
+        CardProgressView(item:  progressItem(id: "신청", title: "신청 후 업체에 입금해주세요", statement: "업체에서 입금 확인 후 제작이 진행됩니다.", isProcessing: true))
+    }
+}

--- a/HANE24/View/More/ReissuanceView.swift
+++ b/HANE24/View/More/ReissuanceView.swift
@@ -8,18 +8,41 @@
 import SwiftUI
 
 struct progressItem: Identifiable{
-    var id: UUID
+    var id: String
     var title: String
     var statement: String
-    
+    var isProcessing: Bool
 }
 
+//
+//var processItems: [progressItem] = [
+//    progressItem(id: "신청", title: "신청 후 업체에 입금해주세요", statement: "업체에서 입금 확인 후 제작이 진행됩니다.", isProcessing: false),
+//    progressItem(id: "제작", title: "제작 기간은 약 2주간 소요됩니다", statement: "출입카드 재발급 신청 후 업체에서 입금 확인 후 제작이 진행됩니다.", isProcessing: false),
+//    progressItem(id: "완료", title: "카드를 수령해주세요", statement: "재발급 카드는 데스크에서 수령 가능합니다", isProcessing: false)
+//]
+
+struct alertItem: Identifiable{
+    var id: String
+    var title1: String
+    var title2: String
+    var statement: String
+    var buttonTitle: String
+}
+
+var items: [alertItem] = [
+    alertItem(id: "신청", title1: "카드 재발급을", title2: "신청하시겠습니까?", statement: "신청 후 취소가 불가능합니다.", buttonTitle: "네, 신청하겠습니다"),
+    alertItem(id: "수령", title1: "저는 카드를 받았음을", title2: "확인했습니다.", statement: "실물 카드를 받은 후 눌러주세요.", buttonTitle: "네, 확인했습니다")
+    
+]
 
 
 
 struct ReissuanceView: View {
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.openURL) private var openURL
+    @EnvironmentObject var hane: Hane
+    @State var showAlert = false
     
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -66,117 +89,52 @@ struct ReissuanceView: View {
                             .font(.system(size: 20, weight: .bold))
                         Spacer()
                     }
-                    /// ProgressView 따로 빼기...
-                    CardProgress
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 20)
+                            .foregroundColor(.white)
+                            .frame(height: 300)
+                        VStack(alignment: .leading){
+                            CardProgressView(item: progressItem(id: "신청", title: "신청 후 업체에 입금해주세요", statement: "업체에서 입금 확인 후 제작이 진행됩니다.", isProcessing: (hane.reissueState == .beforeReissue)))
+                            Image(systemName: "chevron.down")
+                                .foregroundColor(Color(hex: "D9D9D9"))
+                                .padding(.horizontal, 30)
+                            CardProgressView(item:  progressItem(id: "제작", title: "제작 기간은 약 2주간 소요됩니다", statement: "출입카드 재발급 신청 후 업체에서 입금 확인 후 제작이 진행됩니다.", isProcessing: (hane.reissueState == .inProgress)))
+                            Image(systemName: "chevron.down")
+                                .foregroundColor(Color(hex: "D9D9D9"))
+                                .padding(.horizontal, 30)
+                            CardProgressView(item: progressItem(id: "완료", title: "카드를 수령해주세요", statement: "재발급 카드는 데스크에서 수령 가능합니다", isProcessing: (hane.reissueState == .pickUpRequested)))
+                        }
+                    }
                     Spacer()
-                    Button {} label: {
+                    Button (action :{
+                        showAlert.toggle()
+                    },
+                    label: {
                         ZStack{
                             RoundedRectangle(cornerRadius: 10)
-                                .foregroundColor(.gradientPurple)
+                                .foregroundColor((hane.reissueState == .beforeReissue) ? .gradientPurple : .iconColor)
                                 .frame(height: 45)
                             Text("카드 신청하기")
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
                         }
-                    }
+                    })
+                    .disabled(hane.reissueState != .beforeReissue)
                 }
                 .padding(.horizontal, 30)
                 .padding(.bottom, 30)
             }
-        }
-    }
-    
-    var CardProgress: some View {
-        ZStack{
-            RoundedRectangle(cornerRadius: 20)
-                .foregroundColor(.white)
-                .frame(height: 300)
-            VStack(alignment: .leading) {
-                HStack(spacing: 15) {
-                    ZStack{
-                        Circle()
-                        //    .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round))
-                            .foregroundColor(.gradientPurple)
-                            .frame(width: 50, height: 50)
-                        Text("신청")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(Color(hex: "EAEAEA"))
-                    }
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("신청 후 업체에 입금해주세요.")
-                            .font(.system(size: 16, weight: .bold))
-                        Text("업체에서 입금 확인 후 제작이 진행됩니다.")
-                            .font(.system(size: 14, weight: .regular))
-                    }
-                }
-                .padding()
-                Image(systemName: "chevron.down")
-                    .foregroundColor(Color(hex: "D9D9D9"))
-                    .padding(.horizontal, 30)
-                HStack(spacing: 15) {
-                    ZStack{
-                        Text("제작")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(.iconColor)
-                        Circle()
-                            .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round))
-                            .foregroundColor(Color(hex: "EAEAEA"))
-                            .frame(width: 50, height: 50)
-                    }
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("제작 기간은 약 2주간 소요됩니다.")
-                            .font(.system(size: 16, weight: .bold))
-                        Text("출입카드 재발급 신청 후 업체에서 입금 확인 후 제작이 진행됩니다.")
-                            .font(.system(size: 14, weight: .regular))
-                    }
-                        
-                }
-                .padding()
-                Image(systemName: "chevron.down")
-                    .foregroundColor(Color(hex: "D9D9D9"))
-                    .padding(.horizontal, 30)
-                HStack(spacing: 15) {
-                    ZStack{
-                        Text("완료")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(.iconColor)
-                        Circle()
-                            .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round))
-                            .foregroundColor(Color(hex: "EAEAEA"))
-                            .frame(width: 50, height: 50)
-                    }
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("카드를 수령해주세요.")
-                            .font(.system(size: 16, weight: .bold))
-                        Text("재발급 카드는 데스크에서 수령가능합니다.")
-                            .font(.system(size: 14, weight: .regular))
-                    }
-                }
-                .padding()
-                
-            }
-            .foregroundColor(.black)
-            
-        }
-    }
-    var receiveAlert: some View {
-        ZStack{
-            RoundedRectangle(cornerRadius: 20)
-                .foregroundColor(.white)
-            VStack{
-                Text("저는 카드를 ")
+            if showAlert {
+                AlertView(showAlert: $showAlert, item: (hane.reissueState == .beforeReissue) ? items[0] : items[1])
             }
         }
     }
-    var submitAlert: some View {
-        ZStack{
-            
-        }
-    }
+
 }
 
 struct ReissuanceView_Previews: PreviewProvider {
     static var previews: some View {
         ReissuanceView()
+            .environmentObject(Hane())
     }
 }

--- a/HANE24/View/ViewModel/CoreDataVM.swift
+++ b/HANE24/View/ViewModel/CoreDataVM.swift
@@ -63,15 +63,12 @@ class MonthlyLogController {
     }
     
     func resetLogs() {
-//        let storeContainer = container.persistentStoreCoordinator
-//
-//        for store in storeContainer.persistentStores {
-//            do {
-//                try storeContainer.destroyPersistentStore(at: store.url!, ofType: store.type, options: nil)
-//            } catch {
-//                print(error)
-//            }
-//        }
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "MonthlyLog")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+
+        totalLogs.forEach {
+            container.viewContext.delete($0)
+        }
     
     }
     

--- a/HANE24/View/ViewModel/CoreDataVM.swift
+++ b/HANE24/View/ViewModel/CoreDataVM.swift
@@ -63,15 +63,15 @@ class MonthlyLogController {
     }
     
     func resetLogs() {
-        let storeContainer = container.persistentStoreCoordinator
-        
-        for store in storeContainer.persistentStores {
-            do {
-                try storeContainer.destroyPersistentStore(at: store.url!, ofType: store.type, options: nil)
-            } catch {
-                print(error)
-            }
-        }
+//        let storeContainer = container.persistentStoreCoordinator
+//
+//        for store in storeContainer.persistentStores {
+//            do {
+//                try storeContainer.destroyPersistentStore(at: store.url!, ofType: store.type, options: nil)
+//            } catch {
+//                print(error)
+//            }
+//        }
     
     }
     

--- a/HANE24/View/ViewModel/HaneVM.swift
+++ b/HANE24/View/ViewModel/HaneVM.swift
@@ -10,7 +10,14 @@ import WebKit
 import CoreData
 
 enum MyError: Error {
-    case runtimeError(String)
+    case tokenExpired(String)
+}
+
+enum cardState {
+    case beforeReissue
+    case inProgress
+    case pickUpRequested
+    case pickedUp
 }
 
 
@@ -32,12 +39,15 @@ class Hane: ObservableObject {
     @Published var recent6Weeks: [Double] = [123456, 123456, 12344, 123, 1235, 123409]
     @Published var recent6Months: [Double] = [1234560, 1234560, 123440, 1230, 12350, 123409]
     
+    @Published var reissueState: cardState = .beforeReissue
+    
     var monthlyLogController = MonthlyLogController.shared
     
     var inOutLog: InOutLog
     var perMonth: PerMonth
     var mainInfo: MainInfo
     var accumulationTimes: AccumulationTimes
+    var cardReissueState: ReissueState
     
     var APIroot: String
     
@@ -58,18 +68,23 @@ class Hane: ObservableObject {
         
         self.inOutLog = InOutLog(inTimeStamp: nil, outTimeStamp: nil, durationSecond: nil)
         self.perMonth = PerMonth(login: "", profileImage: "", inOutLogs: [])
-        self.mainInfo = MainInfo(login: "", profileImage: "", inoutState: "", tagAt: nil)
+        self.mainInfo = MainInfo(login: "", profileImage: "", inoutState: "", tagAt: nil, gaepo: "", seocho: "")
         self.accumulationTimes = AccumulationTimes(todayAccumationTime: 0, monthAccumationTime: 0)
 
         self.APIroot = "https://" + (Bundle.main.infoDictionary?["API_URL"] as? String ?? "wrong")
+        self.reissueState = .beforeReissue
+        self.cardReissueState = ReissueState(state: "in_progress")
         print("self.APIroot = \(self.APIroot)")
     }
     
     func refresh(date: Date) async throws {
-        try await updateMainInfo()
-        try await updateAccumulationTime()
-        try await updateMonthlyLogs(date: date)
-        print(self.mainInfo)
+        do {
+            try await updateMainInfo()
+            try await updateAccumulationTime()
+            try await updateMonthlyLogs(date: date)
+        } catch {
+            self.isSignIn = false
+        }
     }
     
     func SignOut() {
@@ -87,6 +102,24 @@ class Hane: ObservableObject {
 
 // update Published
 extension Hane {
+    
+    @MainActor
+    func updateReissueState() async throws {
+        do {
+            try await callReissue()
+        } catch {
+            self.reissueState = .beforeReissue
+        }
+        switch cardReissueState.state {
+        case "in_progress":
+            self.reissueState = .inProgress
+        case "pick_up_requested":
+            self.reissueState = .pickUpRequested
+        default:
+            self.reissueState = .pickedUp
+        }
+    }
+    
     @MainActor
     func updateMainInfo() async throws {
         self.loading = true
@@ -218,12 +251,30 @@ extension Hane {
         ]
         let (data, response) = try await URLSession.shared.data(for: request)
         guard (response as? HTTPURLResponse)?.statusCode == 200 else {
-            fatalError("error")
-//            self.isSignIn = false
-//            throw MyError.runtimeError("asdf")
+            throw MyError.tokenExpired("get new token!")
         }
         let decodedData =  try JSONDecoder().decode(type.self, from: data)
         return decodedData
+    }
+    
+    func postJsonAsync() async throws {
+        let urlString = APIroot + "/v1/reissue/request"
+        guard let url = URL(string: urlString) else {
+            fatalError("missingURL")
+        }
+        guard let token = UserDefaults.standard.string(forKey: "Token") else {
+            fatalError("UnValid Token")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.allHTTPHeaderFields = [
+            "Authorization" : "Bearer \(String(describing: token) )"
+        ]
+        
+        let (_ , response) = try await URLSession.shared.data(for: request)
+        guard (response as? HTTPURLResponse)?.statusCode == 201 else {
+            throw MyError.tokenExpired("get new token!")
+        }
     }
     
     func callAccumulationTimes() async throws {
@@ -236,11 +287,15 @@ extension Hane {
     }
     
     func callPerMonth(year: Int, month: Int) async throws {
-        var components = URLComponents(string: APIroot + "/v1/tag-log/permonth")!
+        var components = URLComponents(string: "https://api-dev.24hoursarenotenough.42seoul.kr/v1/tag-log/alltagpermonth")!
         let year = URLQueryItem(name: "year", value: "\(year)")
         let month = URLQueryItem(name: "month", value: "\(month)")
         components.queryItems = [year, month]
         
         self.perMonth = try await callJsonAsync(components.url!.absoluteString, type: PerMonth.self)
+    }
+    
+    func callReissue() async throws {
+        self.cardReissueState = try await callJsonAsync(APIroot + "/v1/reissue", type: ReissueState.self)
     }
 }

--- a/HANE24/View/ViewModel/HaneVM.swift
+++ b/HANE24/View/ViewModel/HaneVM.swift
@@ -287,7 +287,7 @@ extension Hane {
     }
     
     func callPerMonth(year: Int, month: Int) async throws {
-        var components = URLComponents(string: "https://api-dev.24hoursarenotenough.42seoul.kr/v1/tag-log/alltagpermonth")!
+        var components = URLComponents(string: APIroot + "/v1/tag-log/alltagpermonth")!
         let year = URLQueryItem(name: "year", value: "\(year)")
         let month = URLQueryItem(name: "month", value: "\(month)")
         components.queryItems = [year, month]


### PR DESCRIPTION
[link] reissue process
  -> GET reissue, POST reissue/request
  -> [FIXME] 단계 나눠진게 디자인적으로 나눠진 부분이랑 조금 달라서 해당 부분 크리스틴님과 이야기 후에 수정 필요할지도
  ->  [FIXME] PATCH reissue/finish 필요
[link] cadet_per_cluster 
[add] token 만료시에 SignInView로 돌아가게끔
[fix] perMonth API -> alltagpermonth API
  -> [FIXME] 태깅 미싱에 의해 누락된 경우 체류시간 "누락" 이어야 하는데 그냥 "-" 으로 뜨고 있음 + 배경 안 바뀜
[fix] coreDataVM.resestLogs => 기존 코드에서는 로그아웃 이후에 다시 로그인 하는 경우 coredata쪽에서 fatalError  
       -> 지금은 여러명 계정으로 로그인 돌아가면서 해봤을 때에 잘 되는 것 확인하긴했는데..!! 더 테스트 해봐야 할 듯

[FIXME!] webView에서 로그인 실패시에 다시 그냥 SIgnInView로 넘어감 -> 넘어가지 않고 계속 웹뷰에 남아 있을 수 있게 하기
[FIXME!] selectedDate가 그 표준시간대로 설정되어있어서 오전중에는 날짜가 하루 밀리는 문제 있는데 해당 부분이 시뮬레이터에서만 시간이 잘못 적용되는건지 실제 기기에서도 잘못 나오는지. 실 기기에서도 기기 지정 사용 시간대가 아니라면 KR 로 직접 지정해주기


*** reissue, cadet_per_cluster, alltagpermonth 모두 api-dev 에 되어있어서  API_URL api-dev로 변경한 상태로 진행했습니다***
.....배포전에 다시 바꾸는거 잊지 말기.....
 