### PR TITLE
[fix] log delay 9hours issue #68

### DIFF
--- a/HANE24/Utils/DateExtensions.swift
+++ b/HANE24/Utils/DateExtensions.swift
@@ -92,7 +92,7 @@ extension Date {
         Int64((self.timeIntervalSince1970 * 1000.0).rounded())
     }
     init(milliseconds: Int64) {
-        self = Date(timeIntervalSince1970: TimeInterval(milliseconds))
+        self = Date(timeIntervalSince1970: TimeInterval(milliseconds - 9 * 3600))
     }
 }
 

--- a/HANE24/View/Calendar/CalendarView.swift
+++ b/HANE24/View/Calendar/CalendarView.swift
@@ -47,14 +47,15 @@ struct CalendarView: View {
             var inTime: String? = nil
             var outTime: String? = nil
             var logTime: String? = "누락"
-            if let intime = $0.inTimeStamp {
+            if var intime = $0.inTimeStamp {
+                intime += 9 * 3600
                 inTime = Date(milliseconds: intime).toString("HH:mm:ss")
             }
-            if let outtime = $0.outTimeStamp {
+            if var outtime = $0.outTimeStamp {
+                outtime += 9 * 3600
                 outTime = Date(milliseconds: outtime).toString("HH:mm:ss")
             }
             if var logtime = $0.durationSecond {
-                logtime -= 3600 * 9
                 logTime = Date(milliseconds: logtime).toString("HH:mm:ss")
             }
             return Log(inTime: inTime, outTime: outTime, logTime: logTime)


### PR DESCRIPTION
다음달 1일이 로그에 포함되는 오류 해결
Date에서 GMT+9:00 되어있어서 발생
Date init(miliseconds: Int64)시 -9h로 해결