### PR TITLE
[FIX] Image will not be cliped

### DIFF
--- a/HANE24/View/Home/HomeView.swift
+++ b/HANE24/View/Home/HomeView.swift
@@ -102,9 +102,10 @@ struct HomeView: View {
                             AsyncImage(url: URL(string: hane.profileImage)) { image in
                                 image
                                     .resizable()
+                                    .scaledToFill()
                                     .frame(width: 28, height: 28)
-                                    .padding(.trailing, 3)
                                     .clipShape(Circle())
+                                    .padding(.trailing, 3)
                             } placeholder: {
                                 Image(systemName: "person.circle")
                                     .resizable()


### PR DESCRIPTION
이미지가 padding된다음에 clipShape 되는바람에 오른쪽에 3pt 만큼 밀려보였던거같구요

resizable만 있으면 이미지가 맘대로 늘어나서 그냥 scaledtoFill로 맞춰봤는데 제 프사는 별 문제 없었어서 제대로 고친건지는 모르겠네요